### PR TITLE
Better attribute assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v 0.0.3-beta
+Fixes #8. Attributes must be defined on the model or Resource to be assigned. 
+
 v 0.0.2-beta
 Fix issue with `ParamsToObject` relationship parsing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-v 0.0.3-beta
-Fixes #8. Attributes must be defined on the model or Resource to be assigned. 
+v 0.1.0-beta
+Fixes #8. Attributes must be defined on the model or Resource to be assigned.
+Updates #parse_json_api_params interface to be more readable.
 
 v 0.0.2-beta
 Fix issue with `ParamsToObject` relationship parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsonapi_rails (0.0.2.pre.beta)
+    jsonapi_rails (0.0.3.pre.beta)
       hash_validator
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsonapi_rails (0.0.3.pre.beta)
+    jsonapi_rails (0.1.0.pre.beta)
       hash_validator
 
 GEM

--- a/lib/jsonapi_rails/controller_helpers.rb
+++ b/lib/jsonapi_rails/controller_helpers.rb
@@ -10,8 +10,8 @@ module JsonApiRails
 
     # Parses `params_hsh` and passes the resulting model to the given block.
     # Rescues and renders any errors encountered when parsing.
-    def parse_json_api_params(params_hsh, ar_relation = nil, options = {}, &block)
-      parser = Parser.new params_hsh, ar_relation, options
+    def parse_json_api_params(params_hsh, ar_relation: nil, resource_class: nil, &block)
+      parser = Parser.new params_hsh, ar_relation, resource_class
       parser.execute block
     rescue Error => exception
       render json_api_errors: [exception.message]

--- a/lib/jsonapi_rails/controller_helpers.rb
+++ b/lib/jsonapi_rails/controller_helpers.rb
@@ -10,8 +10,8 @@ module JsonApiRails
 
     # Parses `params_hsh` and passes the resulting model to the given block.
     # Rescues and renders any errors encountered when parsing.
-    def parse_json_api_params(params_hsh, ar_relation = nil, &block)
-      parser = Parser.new params_hsh, ar_relation
+    def parse_json_api_params(params_hsh, ar_relation = nil, options = {}, &block)
+      parser = Parser.new params_hsh, ar_relation, options
       parser.execute block
     rescue Error => exception
       render json_api_errors: [exception.message]

--- a/lib/jsonapi_rails/params_to_object.rb
+++ b/lib/jsonapi_rails/params_to_object.rb
@@ -7,12 +7,12 @@ module JsonApiRails
     attr_reader :object
     attr_reader :attributes
 
-    def initialize(data_hash, ar_relation = nil, options = {})
+    def initialize(data_hash, ar_relation = nil, resource_class = nil)
       validate_json(data_hash)
 
       data = data_hash[:data]
       @object = setup_object(data, ar_relation)
-      @options = options
+      @resource_class = resource_class
 
       @attributes = Hash(data[:attributes])
       @relationships = Hash(data[:relationships])
@@ -237,12 +237,20 @@ module JsonApiRails
       end
     end
 
-    # Resolves the Resource class and returns an instance built with `object`
+    # Instanciates a Resource built with `object`
+    #
+    # @return [Resource]
     def resource
-      return @resource if @resource
-      resource_klass =
-        JsonApi::Resources::Discovery.resource_for_name object, @options
-      @resource = resource_klass.new object
+      @resource ||= resource_klass.new object
+    end
+
+    # Resolves the Resource class for `object`
+    #
+    # @return [Resource] the resolved Resource class for `object`
+    def resource_klass
+      @resource_klass ||= JsonApi::Resources::Discovery
+        .resource_for_name object,
+                           resource_class: @resource_class
     end
   end
 end

--- a/lib/jsonapi_rails/params_to_object.rb
+++ b/lib/jsonapi_rails/params_to_object.rb
@@ -7,11 +7,12 @@ module JsonApiRails
     attr_reader :object
     attr_reader :attributes
 
-    def initialize(data_hash, ar_relation = nil)
+    def initialize(data_hash, ar_relation = nil, options = {})
       validate_json(data_hash)
 
       data = data_hash[:data]
       @object = setup_object(data, ar_relation)
+      @options = options
 
       @attributes = Hash(data[:attributes])
       @relationships = Hash(data[:relationships])
@@ -86,7 +87,14 @@ module JsonApiRails
     # Calls the setter method "attr=" with the attribute value for each
     # attribute passed into this class on initialization
     def assign_attributes
-      attributes.each do |attr,value|
+      attributes.each_with_object({}) do |(attr, value), hsh|
+        unless resource.fields_array.include? attr
+          message = "`#{object.class}' does not have attribute " \
+                    "`#{attr.to_s.gsub('=', '')}'"
+          fail UnknownAttributeError.new(message)
+        end
+        hsh[attr] = value if assignable_attribute_names.include? attr.to_s
+      end.each do |attr,value|
         check_method("#{attr}=")
         object.send("#{attr}=", value)
       end
@@ -216,6 +224,25 @@ module JsonApiRails
         result << error_template % {field_name: attr}
       end
       fail ValidationError.new(errors.join(', ')) if errors.present?
+    end
+
+    # Inspects the model using `attribute_names` and selects the attributes
+    # which are also present in the Resource's `fields_array`.
+    #
+    # @return [Array<String>] list of attributes available to assign to the
+    # underlying model
+    def assignable_attribute_names
+      object.attribute_names.select do |attr|
+        resource.fields_array.include? attr.to_sym
+      end
+    end
+
+    # Resolves the Resource class and returns an instance built with `object`
+    def resource
+      return @resource if @resource
+      resource_klass =
+        JsonApi::Resources::Discovery.resource_for_name object, @options
+      @resource = resource_klass.new object
     end
   end
 end

--- a/lib/jsonapi_rails/parser.rb
+++ b/lib/jsonapi_rails/parser.rb
@@ -3,8 +3,8 @@ module JsonApiRails
   # `ParamsToObject`, then extracting the model and passing it to the given
   # block.
   class Parser
-    def initialize(params_hsh, ar_relation = nil, options = {})
-      @wrapper = ParamsToObject.new params_hsh, ar_relation, options
+    def initialize(params_hsh, ar_relation = nil, resource_class = nil)
+      @wrapper = ParamsToObject.new params_hsh, ar_relation, resource_class
     end
 
     # Extracts the model from the wrapper, then passes it to the given block.

--- a/lib/jsonapi_rails/parser.rb
+++ b/lib/jsonapi_rails/parser.rb
@@ -3,8 +3,8 @@ module JsonApiRails
   # `ParamsToObject`, then extracting the model and passing it to the given
   # block.
   class Parser
-    def initialize(params_hsh, ar_relation = nil)
-      @wrapper = ParamsToObject.new params_hsh, ar_relation
+    def initialize(params_hsh, ar_relation = nil, options = {})
+      @wrapper = ParamsToObject.new params_hsh, ar_relation, options
     end
 
     # Extracts the model from the wrapper, then passes it to the given block.

--- a/lib/jsonapi_rails/version.rb
+++ b/lib/jsonapi_rails/version.rb
@@ -1,3 +1,3 @@
 module JsonapiRails
-  VERSION = "0.0.2-beta"
+  VERSION = "0.0.3-beta"
 end

--- a/lib/jsonapi_rails/version.rb
+++ b/lib/jsonapi_rails/version.rb
@@ -1,3 +1,3 @@
 module JsonapiRails
-  VERSION = "0.0.3-beta"
+  VERSION = "0.1.0-beta"
 end

--- a/spec/params_to_object_spec.rb
+++ b/spec/params_to_object_spec.rb
@@ -238,9 +238,8 @@ describe JsonApiRails::ParamsToObject do
               type: 'people'
             }
           },
-          nil, {
-            resource_class: 'AlternatePersonResource'
-          }
+          nil,
+          'AlternatePersonResource'
         )
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,8 +45,18 @@ end
 class PersonResource < JsonApi::Resource
   id_field :uuid
   attribute :name
+  attribute :overridden_name
 
   has_many :articles
+
+  def overridden_name
+    object.name + '!!'
+  end
+end
+
+class AlternatePersonResource < JsonApi::Resource
+  id_field :uuid
+  attribute :name
 end
 
 class ArticleResource < JsonApi::Resource


### PR DESCRIPTION
This fixes #8 by adding model and resource inspection before assignment of an attribute. If the attribute is defined on the model (via `model#attribute_names`), the attribute is assignable. If the attribute is defined on the Resource but not the model, the attribute is ignored. If the attribute is defined on neither, an exception is raised.
