### PR TITLE
Compare symbols to symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v 0.1.1-beta
+Fixes an issue with comparing strings to symbols when building the list of
+assignable attributes.
+
 v 0.1.0-beta
 Fixes #8. Attributes must be defined on the model or Resource to be assigned.
 Updates #parse_json_api_params interface to be more readable.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsonapi_rails (0.1.0.pre.beta)
+    jsonapi_rails (0.1.1.pre.beta)
       hash_validator
 
 GEM

--- a/lib/jsonapi_rails/params_to_object.rb
+++ b/lib/jsonapi_rails/params_to_object.rb
@@ -88,7 +88,7 @@ module JsonApiRails
     # attribute passed into this class on initialization
     def assign_attributes
       attributes.each_with_object({}) do |(attr, value), hsh|
-        unless resource.fields_array.include? attr
+        unless resource.fields_array.include? attr.to_sym
           message = "`#{object.class}' does not have attribute " \
                     "`#{attr.to_s.gsub('=', '')}'"
           fail UnknownAttributeError.new(message)

--- a/lib/jsonapi_rails/version.rb
+++ b/lib/jsonapi_rails/version.rb
@@ -1,3 +1,3 @@
 module JsonapiRails
-  VERSION = "0.1.0-beta"
+  VERSION = "0.1.1-beta"
 end

--- a/spec/params_to_object_spec.rb
+++ b/spec/params_to_object_spec.rb
@@ -48,14 +48,16 @@ describe JsonApiRails::ParamsToObject do
 
   describe 'attributes' do
     it 'updates an attribute' do
-      params_object = JsonApiRails::ParamsToObject.new({
-        data: {
-          type: 'people',
-          attributes: {
-            name: 'mac'
+      params_object = JsonApiRails::ParamsToObject.new(
+        HashWithIndifferentAccess.new({
+          'data' => {
+            'type' => 'people',
+            'attributes' => {
+              'name' => 'mac'
+            }
           }
-        }
-      })
+        })
+      )
       expect(params_object.object.name).to eq 'mac'
     end
 


### PR DESCRIPTION
This ensures that when we build the list of assignable attributes, we're comparing a list of symbols to a list of symbols, instead of a list of strings to a list of symbols. Otherwise, we get unexpected `UnexpectedAttributeError`s. 
