### PR TITLE
Update version.rb

### DIFF
--- a/lib/jsonapi_rails/version.rb
+++ b/lib/jsonapi_rails/version.rb
@@ -1,3 +1,3 @@
 module JsonapiRails
-  VERSION = "0.4.1-beta"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
Fix version number issues like
```
[!] There was an error while loading `jsonapi_rails.gemspec`: Malformed version number string 0.4.1-beta. Bundler cannot continue.

 #  from /Users/jross/.rvm/gems/ruby-2.1.7@bypass-admin/bundler/gems/jsonapi_rails-6d40db6388bb/jsonapi_rails.gemspec:8
 #  -------------------------------------------
 #    spec.name          = "jsonapi_rails"
 >    spec.version       = JsonapiRails::VERSION
 #    spec.authors       = ["Ben Bean"]
 #  -------------------------------------------
```